### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # RescueXcodePlug-ins
-####To Reload your Xcode plug-ins.
-####重新加载 Xcode 插件，用于修复插件消失错误。
+#### To Reload your Xcode plug-ins.
+#### 重新加载 Xcode 插件，用于修复插件消失错误。
 
-####Update
+#### Update
 * Remove args. Now it can fix the xcode plug-ins smartly.
 
-##How to use:
+## How to use:
 
 Run script below.It's now support all version of Xcodes.
 
@@ -14,7 +14,7 @@ Run script below.It's now support all version of Xcodes.
 Restart your Xcode.
 Done!
 
-##如何使用：  
+## 如何使用：  
 运行下面的脚本，现在支持所有的Xcode版本。
 
 `curl -s https://raw.githubusercontent.com/ForkPanda/RescueXcodePlug-ins/master/RescueXcode.sh | sh`


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
